### PR TITLE
fix: fix functions & code refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,66 @@
-
 'use strict';
 
+const path = require('path');
+
+// cache permalink for each post
 const cachedPost = {};
-let lastPost;
-hexo.extend.filter.register('post_permalink', function(data){
-  lastPost = data;
+hexo.extend.filter.register('before_post_render', function(data){
+  const filePath = path.normalize(data.source.replace('_posts/', ''));
+  cachedPost[filePath] = data.permalink;
   return data;
-}, 1);
-hexo.extend.filter.register('post_permalink', function(permalink) {
-  if (lastPost) {
-    const fileName = lastPost.source.replace('_posts/', '');
-    cachedPost[fileName] = permalink;
-  }
-  return permalink;
-}, 25);
+}, 50);
 
-hexo.extend.filter.register("after_render:html", (str) => {
-  const re = /<a[^>]*href[=\"\'\s]+([^\"\']*)[\"\']?[^>]*>/g;
-  return str.replace(re, function(p1, p2) {
-    const fileName = p2.replace(/..\/|.\//g, '').replace(/.md#[\w]+/, '.md');
-    if (cachedPost[fileName]) {
-      const toBeReplacedContent = p2.replace(/.md#[\w]+/, '.md');
-      return p1.replace(toBeReplacedContent, `/${cachedPost[fileName]}`);
+
+// update links in post
+hexo.extend.filter.register('before_post_render', function(data){
+  let currentPostPath = data.source.replace('_posts/', '');
+  data.content = updateLinksInPost(data.content, currentPostPath);
+  return data;
+}, 51);
+
+function updateLinksInPost(postContent, currentPostPath) {
+  // regex matching "[name](link)"
+  const regex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  const replacements = [];
+
+  let match;
+  while ((match = regex.exec(postContent)) !== null) {
+    const [fullMatch, name, link] = match;
+
+    // Check if link ends with ".md" or contains ".md#", and does not contain "://"
+    // These links should be processed, as they points to another post
+    if ((/\.md(#|$)/.test(link)) && !/:\//.test(link)) {
+      // split the link (like "../github/introduction.md#History")
+      const [relativePath, anchor = ''] = link.split("#");
+
+      // resolve the relative link path against current directory
+      const currentDir = path.dirname(currentPostPath);
+      const targetPostPath = path.normalize(path.join(currentDir, relativePath));
+
+      // Is this "targetPostPath" actually points to an existing post?
+      const targetPermalink = cachedPost[targetPostPath]
+      if(!targetPermalink) {
+        continue;
+      }
+
+      // reconstruct the new link
+      const newLink = `${targetPermalink}${anchor ? "#" + anchor : ""}`;
+      const newMarkdownLink = `[${name}](${newLink})`;
+
+      replacements.push({
+        start: match.index,
+        end: match.index + fullMatch.length,
+        replacement: newMarkdownLink,
+      });
+      hexo.log.i(`Replace link ${fullMatch} --> ${newMarkdownLink} in post [${currentPostPath}]`)
     }
-    return p1;
+  }
+
+  // apply replacements in reverse order to avoid index shifting
+  replacements.reverse().forEach(({ start, end, replacement }) => {
+    postContent =
+      postContent.slice(0, start) + replacement + postContent.slice(end);
   });
-});
 
-
-
-
+  return postContent;
+}

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ hexo.extend.filter.register('before_post_render', function(data){
   const filePath = path.normalize(data.source.replace('_posts/', ''));
   cachedPost[filePath] = data.permalink;
   return data;
-}, 50);
+}, 20);
 
 
 // update links in post
@@ -16,7 +16,7 @@ hexo.extend.filter.register('before_post_render', function(data){
   let currentPostPath = data.source.replace('_posts/', '');
   data.content = updateLinksInPost(data.content, currentPostPath);
   return data;
-}, 51);
+}, 21);
 
 function updateLinksInPost(postContent, currentPostPath) {
   // regex matching "[name](link)"


### PR DESCRIPTION
### Changes:
- 将构造每篇post的permalink缓存的任务推迟到`before_post_render`，这样兼容某些在`before_post_render`早期修改permalink的插件
  - 另外，此时获取的permalink是经过配置文件中主URL拼接的完整永久链接（类似`https://<URL>/posts/path/name.md`，而不是仅仅只有`/posts/path/name.md`），这样可以兼容主URL中存在子目录的情况（比如GitHub Pages的默认主URL：`https://user-name.github.io/repo-name`）
- 重构链接替换部分
  - 旧的`after_render:html`监听器似乎已经失效了
  - 将此任务提前到`before_post_render`，将替换`<a>`标签改为替换Markdown链接`[xxx](url)`，这样使过滤更加简单，同时在`before_post_render`中也允许进行相对路径计算
  - 考虑相对路径计算问题：原有代码中直接将..和.移除，然后进行匹配，这导致如果不同目录下有同名博文则可能会发生冲突。这里将逻辑修改为：
    - 匹配markdown链接`[name](link)`，确保link以`.md`结尾或者`.md#anchor`结尾，且不含有符号`://`，保证它是指向另一个markdown的相对路径
    - 将path和anchor拆分开，然后将链接中的path（相对路径）和当前markdown的directory进行拼接，并计算最终的markdown路径
    - 检查permalink缓存，如果计算出的markdown路径确实有对应的permalink，就将这个markdown链接替换为指向正确的permalink（#anchor部分保持不变）